### PR TITLE
Remove simplejson

### DIFF
--- a/sorl/thumbnail/base.py
+++ b/sorl/thumbnail/base.py
@@ -53,8 +53,20 @@ class ThumbnailBackend(object):
         if not thumbnail.exists():
             # We have to check exists() because the Storage backend does not
             # overwrite in some implementations.
-            source_image = default.engine.get_image(source)
-            # We might as well set the size since we have the image in memory
+            # so we make the assumption that if the thumbnail is not cached, it doesn't exist
+            try:
+                source_image = default.engine.get_image(source)
+            except IOError:
+                # if S3Storage says file doesn't exist remotely, don't try to
+                # create it, exit early
+                # Will return working empty image type; 404'd image
+                logger.warn('Remote file [%s] at [%s] does not exist', file_,
+                            geometry_string)
+                return thumbnail
+                # We might as well set the size since we have the image in memory
+            image_info = default.engine.get_image_info(source_image)
+            options['image_info'] = image_info
+
             size = default.engine.get_image_size(source_image)
             source.set_size(size)
             self._create_thumbnail(source_image, geometry_string, options,

--- a/sorl/thumbnail/engines/base.py
+++ b/sorl/thumbnail/engines/base.py
@@ -66,11 +66,13 @@ class EngineBase(object):
         """
         format_ = options['format']
         quality = options['quality']
+        image_info = options['image_info']
         # additional non-default-value options:
         progressive = options.get('progressive', settings.THUMBNAIL_PROGRESSIVE)
         raw_data = self._get_raw_data(image, format_, quality,
-            progressive=progressive
-            )
+                                      image_info=image_info,
+                                      progressive=progressive
+        )
         thumbnail.write(raw_data)
 
     def get_image_ratio(self, image):
@@ -79,6 +81,12 @@ class EngineBase(object):
         """
         x, y = self.get_image_size(image)
         return float(x) / y
+
+    def get_image_info(self, image):
+        """
+        Returns metadata of an ImageFile instance
+        """
+        return {}
 
     #
     # Methods which engines need to implement
@@ -130,7 +138,7 @@ class EngineBase(object):
         """
         raise NotImplemented()
 
-    def _get_raw_data(self, image, format_, quality, progressive=False):
+    def _get_raw_data(self, image, format_, quality, image_info=None, progressive=False):
         """
         Gets raw data given the image, format and quality. This method is
         called from :meth:`write`

--- a/sorl/thumbnail/engines/pgmagick_engine.py
+++ b/sorl/thumbnail/engines/pgmagick_engine.py
@@ -66,7 +66,7 @@ class Engine(EngineBase):
         image.crop(geometry)
         return image
 
-    def _get_raw_data(self, image, format_, quality, progressive=False):
+    def _get_raw_data(self, image, format_, quality, image_info=None, progressive=False):
         image.magick(format_.encode('utf8'))
         image.quality(quality)
         if format_ == 'JPEG' and progressive:

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -68,7 +68,7 @@ class Engine(EngineBase):
         return image.crop((x_offset, y_offset,
                            width + x_offset, height + y_offset))
 
-    def _get_raw_data(self, image, format_, quality, progressive=False):
+    def _get_raw_data(self, image, format_, quality, image_info, progressive=False):
         ImageFile.MAXBLOCK = 1024 * 1024
         buf = StringIO()
         params = {

--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -15,6 +15,9 @@ class Engine(EngineBase):
     def get_image_size(self, image):
         return image.size
 
+    def get_image_info(self, image):
+        return image.info or {}
+
     def is_valid_image(self, raw_data):
         buf = StringIO(raw_data)
         try:
@@ -73,6 +76,9 @@ class Engine(EngineBase):
             'quality': quality,
             'optimize': 1,
         }
+
+        params.update(image_info)
+
         if format_ == 'JPEG' and progressive:
             params['progressive'] = True
         try:

--- a/sorl/thumbnail/helpers.py
+++ b/sorl/thumbnail/helpers.py
@@ -1,15 +1,15 @@
 import hashlib
+import json
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.encoding import smart_str
 from django.utils.importlib import import_module
-from django.utils import simplejson
 
 
 class ThumbnailError(Exception):
     pass
 
 
-class SortedJSONEncoder(simplejson.JSONEncoder):
+class SortedJSONEncoder(json.JSONEncoder):
     """
     A json encoder that sorts the dict keys
     """
@@ -37,11 +37,11 @@ def tokey(*args):
 
 
 def serialize(obj):
-    return simplejson.dumps(obj, cls=SortedJSONEncoder)
+    return json.dumps(obj, cls=SortedJSONEncoder)
 
 
 def deserialize(s):
-    return simplejson.loads(s)
+    return json.loads(s)
 
 
 def get_module_class(class_path):

--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -1,3 +1,4 @@
+import json
 import re
 import urllib2
 from django.core.files.base import File, ContentFile
@@ -5,7 +6,6 @@ from django.core.files.storage import Storage, default_storage
 from django.core.urlresolvers import reverse
 from django.utils.encoding import force_unicode
 from django.utils.functional import LazyObject
-from django.utils import simplejson
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.helpers import ThumbnailError, tokey, get_module_class
 from sorl.thumbnail import default
@@ -24,11 +24,11 @@ def serialize_image_file(image_file):
         'storage': image_file.serialize_storage(),
         'size': image_file.size,
     }
-    return simplejson.dumps(data)
+    return json.dumps(data)
 
 
 def deserialize_image_file(s):
-    data = simplejson.loads(s)
+    data = json.loads(s)
     class LazyStorage(LazyObject):
         def _setup(self):
             self._wrapped = get_module_class(data['storage'])()


### PR DESCRIPTION
This PR updates the code to use json from the standard library, instead of the deprecated simplejson from django contrib.